### PR TITLE
Fix absolute path in tutorial profile

### DIFF
--- a/jaffle_shop_duckdb/mf_tutorial_project/profiles.yml
+++ b/jaffle_shop_duckdb/mf_tutorial_project/profiles.yml
@@ -3,5 +3,5 @@ mf_tutorial:
   outputs:
     dev:
       type: duckdb
-      path: '/Users/jbanner/Code/mcp_test/jaffle_shop_duckdb/mf_tutorial_project/mf_tutorial.duckdb'
+      path: 'mf_tutorial_project/mf_tutorial.duckdb'
 


### PR DESCRIPTION
## Summary
- use a relative DuckDB path for the MetricFlow tutorial profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f3fe45f28832db668dc5ceb6bdb38